### PR TITLE
Solving conflict with buffer-loader

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const path = require('path')
 const isNode = !global.window
 
 // protobuf read from file
-const messages = isNode ? protobuf(fs.readFileSync(path.resolve(__dirname, 'pb/crypto.proto'))) : protobuf(require('buffer!./pb/crypto.proto'))
+const messages = isNode ? protobuf(fs.readFileSync(path.resolve(__dirname, 'pb/crypto.proto'))) : protobuf(require('buffer-loader!./pb/crypto.proto'))
 
 exports = module.exports = Id
 


### PR DESCRIPTION
Thanks to @xicombd I've found that if you, by some reason, depend on both this project and https://github.com/feross/buffer, you'll have some conflicts between `buffer` and the `buffer-loader` unless you explicitly require it.